### PR TITLE
Enable Status subresource on SampleSource

### DIFF
--- a/config/crds/sources_v1alpha1_samplesource.yaml
+++ b/config/crds/sources_v1alpha1_samplesource.yaml
@@ -11,6 +11,8 @@ spec:
     kind: SampleSource
     plural: samplesources
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/sources/v1alpha1/samplesource_types.go
+++ b/pkg/apis/sources/v1alpha1/samplesource_types.go
@@ -51,6 +51,7 @@ type SampleSourceStatus struct {
 
 // SampleSource is the Schema for the samplesources API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type SampleSource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/sources/v1alpha1/samplesource_types_test.go
+++ b/pkg/apis/sources/v1alpha1/samplesource_types_test.go
@@ -53,16 +53,23 @@ func TestStorageSampleSource(t *testing.T) {
 	g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
 	g.Expect(fetched).To(gomega.Equal(created))
 
-	// Test Updating the Labels and Status
+	// Test Updating the Labels
 	updated := fetched.DeepCopy()
 	updated.Labels = map[string]string{"hello": "world"}
+	g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+	g.Expect(fetched).To(gomega.Equal(updated))
+
+	// Test Updating the Status via subresource
 	updated.Status = SampleSourceStatus{
 		SinkURI: "http://example.com",
 	}
-	g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
-
+	// DeepCopy is required here because the Status update will set the SelfLink
+	// to reference to /status subresource instead of the original resource.
+	statusupdated := updated.DeepCopy()
+	g.Expect(c.Status().Update(context.TODO(), statusupdated)).NotTo(gomega.HaveOccurred())
 	g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
-	g.Expect(fetched).To(gomega.Equal(updated))
+	g.Expect(fetched.Status).To(gomega.Equal(updated.Status))
 
 	// Test Delete
 	g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Allows the controller to only update the status of an object, ignoring the spec.

Tests now update the labels and status in separate requests.