### PR TITLE
Revert "Resolve SinkURI from the source's Sink reference"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -941,7 +941,6 @@
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",

--- a/pkg/controller/samplesource/samplesource_controller.go
+++ b/pkg/controller/samplesource/samplesource_controller.go
@@ -18,14 +18,10 @@ package samplesource
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	sourcesv1alpha1 "github.com/knative/sample-source/pkg/apis/sources/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -121,64 +117,6 @@ func (r *ReconcileSampleSource) Reconcile(request reconcile.Request) (reconcile.
 }
 
 func (r *ReconcileSampleSource) reconcile(ctx context.Context, instance *sourcesv1alpha1.SampleSource) error {
-	// Resolve the Sink URI based on the sink reference.
-	sinkURI, err := r.resolveSinkRef(ctx, instance.Spec.Sink)
-	if err != nil {
-		return fmt.Errorf("Failed to get sink URI: %v", err)
-	}
-
-	// Set the SinkURI field on the SampleSource Status.
-	instance.Status.SinkURI = sinkURI
-
-	//TODO(user): Add additional behavior.
+	//TODO(user): Implement reconciliation
 	return nil
-}
-
-// TODO(user): This is here to improve clarity and reduce the number of vendored
-// libraries. Consider using AddressableType from github.com/knative/pkg instead.
-type addressableType struct {
-	Status struct {
-		Address *struct {
-			Hostname string
-		}
-	}
-}
-
-// TODO(user): A version of this function is also available in the
-// github.com/knative/eventing-sources/pkg/controller/sinks package.
-func (r *ReconcileSampleSource) resolveSinkRef(ctx context.Context, sinkRef *corev1.ObjectReference) (string, error) {
-	// Make sure the reference is not nil.
-	if sinkRef == nil {
-		return "", fmt.Errorf("sink reference is nil")
-	}
-
-	//TODO(user): Add support for corev1.Service.
-
-	// Get the referenced Sink as an Unstructured object.
-	sink := &unstructured.Unstructured{}
-	sink.SetGroupVersionKind(sinkRef.GroupVersionKind())
-	if err := r.Get(ctx, client.ObjectKey{Namespace: sinkRef.Namespace, Name: sinkRef.Name}, sink); err != nil {
-		return "", fmt.Errorf("Failed to get sink object: %v", err)
-	}
-
-	// Marshal the Sink into an Addressable struct to more easily extract its
-	// hostname.
-	addressable := &addressableType{}
-	raw, err := sink.MarshalJSON()
-	if err != nil {
-		return "", fmt.Errorf("Failed to marshal sink: %v", err)
-	}
-	if err := json.Unmarshal(raw, addressable); err != nil {
-		return "", fmt.Errorf("Failed to marshal sink into Addressable: %v", err)
-	}
-
-	// Check that the Addressable fields are present.
-	if addressable.Status.Address == nil {
-		return "", fmt.Errorf("Failed to resolve sink URI: sink does not contain address")
-	}
-	if addressable.Status.Address.Hostname == "" {
-		return "", fmt.Errorf("Failed to resolve sink URI: address hostname is empty")
-	}
-	// Translate the Hostname into a URI.
-	return fmt.Sprintf("http://%s/", addressable.Status.Address.Hostname), nil
 }

--- a/pkg/controller/samplesource/samplesource_controller_suite_test.go
+++ b/pkg/controller/samplesource/samplesource_controller_suite_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/knative/sample-source/pkg/apis"
 	"github.com/onsi/gomega"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -39,20 +37,6 @@ var cfg *rest.Config
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
-		CRDs: []*apiextensionsv1beta1.CustomResourceDefinition{{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "testsinks.sources.knative.dev",
-			},
-			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-				Group: "sources.knative.dev",
-				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-					Kind:   "TestSink",
-					Plural: "testsinks",
-				},
-				Scope:   apiextensionsv1beta1.NamespaceScoped,
-				Version: "v1alpha1",
-			},
-		}},
 	}
 	apis.AddToScheme(scheme.Scheme)
 

--- a/pkg/controller/samplesource/samplesource_controller_test.go
+++ b/pkg/controller/samplesource/samplesource_controller_test.go
@@ -23,11 +23,8 @@ import (
 	sourcesv1alpha1 "github.com/knative/sample-source/pkg/apis/sources/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -37,47 +34,12 @@ import (
 var c client.Client
 
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
-var srcKey = types.NamespacedName{Name: "foo", Namespace: "default"}
 
 const timeout = time.Second * 5
 
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-
-	// Create a TestSink
-	sink := &unstructured.Unstructured{}
-	sink.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "sources.knative.dev",
-		Version: "v1alpha1",
-		Kind:    "TestSink",
-	})
-	sink.SetName("foosink")
-	sink.SetNamespace("default")
-	sink.SetUnstructuredContent(
-		map[string]interface{}{
-			"Status": map[string]interface{}{
-				"Address": map[string]interface{}{
-					"Hostname": "example.com",
-				},
-			},
-		},
-	)
-
-	// Create an instance referencing the TestSink
-	instance := &sourcesv1alpha1.SampleSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      srcKey.Name,
-			Namespace: srcKey.Namespace,
-		},
-		Spec: sourcesv1alpha1.SampleSourceSpec{
-			Sink: &corev1.ObjectReference{
-				APIVersion: "sources.knative.dev/v1alpha1",
-				Kind:       "TestSink",
-				Name:       "foosink",
-				Namespace:  "default",
-			},
-		},
-	}
+	instance := &sourcesv1alpha1.SampleSource{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.
@@ -95,15 +57,6 @@ func TestReconcile(t *testing.T) {
 		mgrStopped.Wait()
 	}()
 
-	// Create the Sink
-	err = c.Create(context.TODO(), sink)
-	// The instance object may not be a valid object because it might be missing some required fields.
-	// Please modify the instance object by adding required fields and then remove the following if statement.
-	if apierrors.IsInvalid(err) {
-		t.Logf("failed to create object, got an invalid object error: %v", err)
-		return
-	}
-
 	// Create the SampleSource object and expect the Reconcile
 	err = c.Create(context.TODO(), instance)
 	// The instance object may not be a valid object because it might be missing some required fields.
@@ -115,20 +68,5 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), instance)
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
-
-	// Expect the SampleSource object to be updated with the SinkURI
-	updatedInstance := &sourcesv1alpha1.SampleSource{}
-	g.Eventually(func() error {
-		if err := c.Get(context.TODO(), srcKey, updatedInstance); err != nil {
-			return err
-		}
-		if updatedInstance.Status.SinkURI != "http://example.com/" {
-			t.Errorf("Unexpected SinkURI: want %q, got %q", "https://example.com/", updatedInstance.Status.SinkURI)
-		}
-		return nil
-	}, timeout).Should(gomega.Succeed())
-
-	// Delete sink
-	g.Expect(c.Delete(context.TODO(), sink)).To(gomega.Succeed())
 
 }


### PR DESCRIPTION
Reverts grantr/sample-source#7. The tests didn't pass because `SetUnstructuredContent` must be called before any other `Set*` methods.